### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ git commits and tags, and push the `.gem` file to
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/habitat-sh/dcob. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
-
+Bug reports and pull requests are welcome on GitHub at https://github.com/habitat-sh/dcob. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org/) code of conduct.
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-


### PR DESCRIPTION
The link tried to go to a relative path when in Github

Signed-off-by: Tim Smith tsmith@chef.io
