### PR TITLE
add a link to failed DCO status to info about DCO

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The bot requires a toml configuration file with three settings:
 login = "GITHUB_USERNAME"
 access_token = "GITHUB_ACCESS_TOKEN"
 secret_token = "SECRET_TOKEN"
+dco_info_url = "https://a.webpage.explaining.what.the.dco.is/and.how.to.sign-off"
 ```
 
 These can also be set in your environment:
@@ -25,11 +26,13 @@ These can also be set in your environment:
 GITHUB_LOGIN
 GITHUB_ACCESS_TOKEN
 GITHUB_SECRET_TOKEN
+DCO_INFO_URL
 ```
 
 The login is a github username; the access token is a personal access token
 that has the Repo privilege. The secret token is the one you specify when you
-add the bot as a webhook.
+add the bot as a webhook. The DCO info URL should lead to a page about the
+Developer Certificate of Origin and how contributors can sign-off their commits.
 
 ## Development
 

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -6,3 +6,6 @@ access_token = ""
 
 # The secret token, specified in the GitHub webhook
 secret_token = ""
+
+# The target_url to supply for all DCO status checks at GitHub
+dco_info_url = "http://developercertificate.org/"

--- a/lib/dcob.rb
+++ b/lib/dcob.rb
@@ -24,14 +24,15 @@ module Dcob
                                   commit["sha"],
                                   "failure",
                                   :context => "DCO",
-                                  :description => "This commit does not have a DCO Signed-off-by",
-                                  :target_url => "https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco")
+                                  :target_url => DCO_INFO_URL,
+                                  :description => "This commit does not have a DCO Signed-off-by")
           else
             puts "Flagging SHA #{commit["sha"]} as succeeded; has DCO"
             Octokit.create_status(repo_id,
                                   commit["sha"],
                                   "success",
                                   :context => "DCO",
+                                  :target_url => DCO_INFO_URL,
                                   :description => "This commit has a DCO Signed-off-by")
           end
         end
@@ -50,6 +51,7 @@ if ENV["GITHUB_LOGIN"] && ENV["GITHUB_ACCESS_TOKEN"] && ENV["GITHUB_SECRET_TOKEN
   Octokit.login = ENV["GITHUB_LOGIN"]
   Octokit.access_token = ENV["GITHUB_ACCESS_TOKEN"]
   SECRET_TOKEN = ENV["GITHUB_SECRET_TOKEN"]
+  DCO_INFO_URL = ENV["DCO_INFO_URL"] || "http://developercertificate.org/"
 else
   if !File.exists?("config.toml")
     puts "You need to provide a config.toml"
@@ -75,6 +77,13 @@ else
     SECRET_TOKEN = config["cfg"]["secret_token"]
   else
     puts "You must specify cfg.secret_token in config.toml"
+    exit 1
+  end
+
+  if config["cfg"]["dco_info_url"]
+    DCO_INFO_URL = config["cfg"]["dco_info_url"]
+  else
+    puts "You must specify cfg.dco_info_url in config.toml"
     exit 1
   end
 end

--- a/lib/dcob.rb
+++ b/lib/dcob.rb
@@ -24,7 +24,8 @@ module Dcob
                                   commit["sha"],
                                   "failure",
                                   :context => "DCO",
-                                  :description => "This commit does not have a DCO Signed-off-by")
+                                  :description => "This commit does not have a DCO Signed-off-by",
+                                  :target_url => "https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco")
           else
             puts "Flagging SHA #{commit["sha"]} as succeeded; has DCO"
             Octokit.create_status(repo_id,
@@ -56,7 +57,7 @@ else
   end
 
   config = TOML.load_file("config.toml")
-  if config["cfg"]["login"] 
+  if config["cfg"]["login"]
     Octokit.login = config["cfg"]["login"]
   else
     puts "You must specify cfg.login in config.toml"


### PR DESCRIPTION
Make a failed DCO status include a link to our DCO information in the chef/chef CONTRIBUTING doc. Is chef/chef a weird thing to link to from this habitat-sh project?

Also, bonus removal of trailing whitespace.

(First commit intentionally not signed-off, but dcob is not currently monitoring dcob it seems. 😄 )
