### PR TITLE
set hab pkg version based on the gem's version

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=dcob
 pkg_origin=core
-pkg_version=0.1.0
+pkg_version=_computed_
 pkg_description="This is a github bot to ensure every commit on a PR has the
   Signed-off-by attribution required by the Developer Certificate of Origin."
 pkg_upstream_url=https://github.com/habitat-sh/dcob
@@ -20,7 +20,16 @@ pkg_bin_dirs=(bin)
 pkg_svc_run="dcob -o 0.0.0.0"
 pkg_expose=(4567)
 
+determine_version() {
+  pkg_version=$(ruby -I$PLAN_CONTEXT/../src/lib/dcob -rversion -e 'puts Dcob::VERSION')
+  pkg_dirname=${pkg_name}-${pkg_version}
+  pkg_filename=${pkg_dirname}.tar.gz
+  pkg_prefix=$HAB_PKG_PATH/${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}
+  pkg_artifact="$HAB_CACHE_ARTIFACT_PATH/${pkg_origin}-${pkg_name}-${pkg_version}-${pkg_release}-${pkg_target}.${_artifact_ext}"
+}
+
 do_download() {
+  determine_version
   return 0
 }
 


### PR DESCRIPTION
This way, we only have to bump a version in one place.

Plopped this logic in a function and made it responsible for recomputing
hab plan variables that are based on $pkg_version.