### PR TITLE
add failure for signoffs from the doc example

### DIFF
--- a/src/.rubocop.yml
+++ b/src/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.3

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in dcob.gemspec

--- a/src/Guardfile
+++ b/src/Guardfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 guard :rspec, cmd: "bundle exec rspec -f documentation" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)

--- a/src/Rakefile
+++ b/src/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "chefstyle"

--- a/src/bin/console
+++ b/src/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "dcob"

--- a/src/bin/dcob
+++ b/src/bin/dcob
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "pathname"
 path = Pathname.new(__FILE__)

--- a/src/config.ru
+++ b/src/config.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "dcob"
 
 run Dcob::Server

--- a/src/dcob.gemspec
+++ b/src/dcob.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "dcob/version"

--- a/src/lib/dcob.rb
+++ b/src/lib/dcob.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "dcob/version"
 require "sinatra"
 require "octokit"

--- a/src/lib/dcob/octoclient.rb
+++ b/src/lib/dcob/octoclient.rb
@@ -38,18 +38,14 @@ module Dcob
       commits.map do |commit|
         case commit[:commit][:message]
         when /Signed-off-by: Julia Child <juliachild@chef.io>/
-          puts "Flagging SHA #{commit[:sha]} as failed; slavishly followed documentation."
           dco_check_failure(repository_id: repository_id, commit_sha: commit[:sha],
                             message: "Invalid sign-off: Julia Child was not the author of this commit.")
         when /Signed[-|\s]off[-|\s]by: .+ <.+>/i
-          puts "Flagging SHA #{commit[:sha]} as succeeded; has DCO"
           dco_check_success(repository_id: repository_id, commit_sha: commit[:sha])
         when /obvious fix/i
-          puts "Flagging SHA #{commit[:sha]} as succeeded; obvious fix declared"
           dco_check_success(repository_id: repository_id, commit_sha: commit[:sha],
                             message: "This commit declared that it is an obvious fix")
         else
-          puts "Flagging SHA #{commit[:sha]} as failed; no DCO"
           dco_check_failure(repository_id: repository_id, commit_sha: commit[:sha])
         end
       end
@@ -57,6 +53,7 @@ module Dcob
 
     def dco_check_success(repository_id:, commit_sha:,
                           message: "This commit has a DCO Signed-off-by")
+      puts "Flagging SHA #{commit_sha} as succeeded; #{message}"
       client.create_status(repository_id,
                            commit_sha,
                            "success",
@@ -67,6 +64,7 @@ module Dcob
 
     def dco_check_failure(repository_id:, commit_sha:,
                           message: "This commit does not have a DCO Signed-off-by")
+      puts "Flagging SHA #{commit_sha} as failed; #{message}"
       client.create_status(repository_id,
                            commit_sha,
                            "failure",

--- a/src/lib/dcob/octoclient.rb
+++ b/src/lib/dcob/octoclient.rb
@@ -43,10 +43,11 @@ module Dcob
                             message: "Invalid sign-off: Julia Child was not the author of this commit.")
         when /Signed[-|\s]off[-|\s]by: .+ <.+>/i
           puts "Flagging SHA #{commit[:sha]} as succeeded; has DCO"
-          dco_check_success(repository_id, commit[:sha])
+          dco_check_success(repository_id: repository_id, commit_sha: commit[:sha])
         when /obvious fix/i
           puts "Flagging SHA #{commit[:sha]} as succeeded; obvious fix declared"
-          obvious_fix_check_success(repository_id, commit[:sha])
+          dco_check_success(repository_id: repository_id, commit_sha: commit[:sha],
+                            message: "This commit declared that it is an obvious fix")
         else
           puts "Flagging SHA #{commit[:sha]} as failed; no DCO"
           dco_check_failure(repository_id: repository_id, commit_sha: commit[:sha])
@@ -54,13 +55,14 @@ module Dcob
       end
     end
 
-    def dco_check_success(repository_id, commit_sha)
+    def dco_check_success(repository_id:, commit_sha:,
+                          message: "This commit has a DCO Signed-off-by")
       client.create_status(repository_id,
                            commit_sha,
                            "success",
                            context: "DCO",
                            target_url: DCO_INFO_URL,
-                           description: "This commit has a DCO Signed-off-by")
+                           description: message)
     end
 
     def dco_check_failure(repository_id:, commit_sha:,
@@ -71,15 +73,6 @@ module Dcob
                            context: "DCO",
                            target_url: DCO_INFO_URL,
                            description: message)
-    end
-
-    def obvious_fix_check_success(repository_id, commit_sha)
-      client.create_status(repository_id,
-                           commit_sha,
-                           "success",
-                           context: "DCO",
-                           target_url: DCO_INFO_URL,
-                           description: "This commit declared that it is an obvious fix")
     end
 
     def client

--- a/src/lib/dcob/octoclient.rb
+++ b/src/lib/dcob/octoclient.rb
@@ -39,7 +39,8 @@ module Dcob
         case commit[:commit][:message]
         when /Signed-off-by: Julia Child <juliachild@chef.io>/
           puts "Flagging SHA #{commit[:sha]} as failed; slavishly followed documentation."
-          dco_check_failure(repository_id, commit[:sha], "Invalid sign-off: Julia Child was not the author of this commit.")
+          dco_check_failure(repository_id: repository_id, commit_sha: commit[:sha],
+                            message: "Invalid sign-off: Julia Child was not the author of this commit.")
         when /Signed[-|\s]off[-|\s]by: .+ <.+>/i
           puts "Flagging SHA #{commit[:sha]} as succeeded; has DCO"
           dco_check_success(repository_id, commit[:sha])
@@ -48,7 +49,7 @@ module Dcob
           obvious_fix_check_success(repository_id, commit[:sha])
         else
           puts "Flagging SHA #{commit[:sha]} as failed; no DCO"
-          dco_check_failure(repository_id, commit[:sha])
+          dco_check_failure(repository_id: repository_id, commit_sha: commit[:sha])
         end
       end
     end
@@ -62,8 +63,8 @@ module Dcob
                            description: "This commit has a DCO Signed-off-by")
     end
 
-    def dco_check_failure(repository_id, commit_sha,
-                          message = "This commit does not have a DCO Signed-off-by")
+    def dco_check_failure(repository_id:, commit_sha:,
+                          message: "This commit does not have a DCO Signed-off-by")
       client.create_status(repository_id,
                            commit_sha,
                            "failure",

--- a/src/lib/dcob/octoclient.rb
+++ b/src/lib/dcob/octoclient.rb
@@ -37,6 +37,9 @@ module Dcob
       # using map to return a collection of status creation responses
       commits.map do |commit|
         case commit[:commit][:message]
+        when /Signed-off-by: Julia Child <juliachild@chef.io>/
+          puts "Flagging SHA #{commit[:sha]} as failed; slavishly followed documentation."
+          dco_check_failure(repository_id, commit[:sha], "Invalid sign-off: Julia Child was not the author of this commit.")
         when /Signed[-|\s]off[-|\s]by: .+ <.+>/i
           puts "Flagging SHA #{commit[:sha]} as succeeded; has DCO"
           dco_check_success(repository_id, commit[:sha])
@@ -59,13 +62,14 @@ module Dcob
                            description: "This commit has a DCO Signed-off-by")
     end
 
-    def dco_check_failure(repository_id, commit_sha)
+    def dco_check_failure(repository_id, commit_sha,
+                          message = "This commit does not have a DCO Signed-off-by")
       client.create_status(repository_id,
                            commit_sha,
                            "failure",
                            context: "DCO",
                            target_url: DCO_INFO_URL,
-                           description: "This commit does not have a DCO Signed-off-by")
+                           description: message)
     end
 
     def obvious_fix_check_success(repository_id, commit_sha)

--- a/src/lib/dcob/octoclient.rb
+++ b/src/lib/dcob/octoclient.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "octokit"
 
 module Dcob

--- a/src/lib/dcob/version.rb
+++ b/src/lib/dcob/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Dcob
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.0"
 end

--- a/src/spec/dcob_spec.rb
+++ b/src/spec/dcob_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Dcob do

--- a/src/spec/octoclient_spec.rb
+++ b/src/spec/octoclient_spec.rb
@@ -139,6 +139,16 @@ describe Dcob::Octoclient do
       expect(subject).to receive(:obvious_fix_check_success).twice
       subject.apply_commit_statuses(123, 456)
     end
+
+    it "sets failed on commits with contact information from our contributing doc" do
+      a_commit_from_julia = commit_factory [
+        "Signed-off-by: Julia Child <juliachild@chef.io>",
+      ]
+      allow(subject.client).to receive(:pull_request_commits).and_return(a_commit_from_julia)
+      expect(subject).to receive(:dco_check_failure).with(123, 1, "Invalid sign-off: Julia Child was not the author of this commit.").once
+      expect(subject).not_to receive(:dco_check_success)
+      subject.apply_commit_statuses(123, 456)
+    end
   end
 
   describe "#dco_check_success" do

--- a/src/spec/octoclient_spec.rb
+++ b/src/spec/octoclient_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Dcob::Octoclient do

--- a/src/spec/octoclient_spec.rb
+++ b/src/spec/octoclient_spec.rb
@@ -136,7 +136,8 @@ describe Dcob::Octoclient do
         "This is an Obvious fix, too.",
       ]
       allow(subject.client).to receive(:pull_request_commits).and_return(obvious_fixes)
-      expect(subject).to receive(:obvious_fix_check_success).twice
+      expect(subject).to receive(:dco_check_success).with(repository_id: 123, commit_sha: 1, message: "This commit declared that it is an obvious fix").once
+      expect(subject).to receive(:dco_check_success).with(repository_id: 123, commit_sha: 2, message: "This commit declared that it is an obvious fix").once
       subject.apply_commit_statuses(123, 456)
     end
 
@@ -159,7 +160,18 @@ describe Dcob::Octoclient do
             target_url: DCO_INFO_URL,
             description: "This commit has a DCO Signed-off-by")
 
-      subject.dco_check_success(:repo_id, :commit_sha)
+      subject.dco_check_success(repository_id: :repo_id, commit_sha: :commit_sha)
+    end
+
+    it "accepts a message to include in the success result" do
+      expect(subject.client).to receive(:create_status)
+      .with(:repo_id, :commit_sha, "success",
+            context: "DCO",
+            target_url: DCO_INFO_URL,
+            description: "Customized!")
+
+      subject.dco_check_success(repository_id: :repo_id, commit_sha: :commit_sha,
+                                message: "Customized!")
     end
   end
 

--- a/src/spec/octoclient_spec.rb
+++ b/src/spec/octoclient_spec.rb
@@ -145,7 +145,7 @@ describe Dcob::Octoclient do
         "Signed-off-by: Julia Child <juliachild@chef.io>",
       ]
       allow(subject.client).to receive(:pull_request_commits).and_return(a_commit_from_julia)
-      expect(subject).to receive(:dco_check_failure).with(123, 1, "Invalid sign-off: Julia Child was not the author of this commit.").once
+      expect(subject).to receive(:dco_check_failure).with(repository_id: 123, commit_sha: 1, message: "Invalid sign-off: Julia Child was not the author of this commit.").once
       expect(subject).not_to receive(:dco_check_success)
       subject.apply_commit_statuses(123, 456)
     end
@@ -171,7 +171,18 @@ describe Dcob::Octoclient do
             target_url: DCO_INFO_URL,
             description: "This commit does not have a DCO Signed-off-by")
 
-      subject.dco_check_failure :repo_id, :commit_sha
+      subject.dco_check_failure repository_id: :repo_id, commit_sha: :commit_sha
+    end
+
+    it "accepts a message to include in the failure result" do
+      expect(subject.client).to receive(:create_status)
+      .with(:repo_id, :commit_sha, "failure",
+            context: "DCO",
+            target_url: DCO_INFO_URL,
+            description: "Customized!")
+
+      subject.dco_check_failure(repository_id: :repo_id, commit_sha: :commit_sha,
+                                message: "Customized!")
     end
   end
 end

--- a/src/spec/spec_helper.rb
+++ b/src/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "dcob"
 require "rspec"


### PR DESCRIPTION
A signoff of "Signed-off-by: Julia Child <juliachild@chef.io>" is a sign that someone has followed the documentation a little too closely. We know Julia was not the author or committer of the commit, so mark it as
failed.

Alternatively—or as a follow-on to this—we could consider validating the sign-off information a bit more deeply. We could change the check to confirm that a commit's author or committer email appears in a sign-off entry.